### PR TITLE
Fix PHP error trying to count a non-array or non countable object.

### DIFF
--- a/model/fieldtypes/SimpleListFieldDB.php
+++ b/model/fieldtypes/SimpleListFieldDB.php
@@ -47,14 +47,20 @@ class SimpleListFieldDB extends Text{
     /**
      * Count items
      */
-    public function Count(){
+    public function Count()
+    {
         $list = $this->getList();
 
-        return (
-            isset($list->items) &&
-            !empty($list->items) &&
-            (is_array($list->items) || $list->items instanceof Countable)
-        ) ? count($list->items) : false;
+        if (!isset($list->items) || empty($list->items)) {
+            return false;
+        }
+
+        $items = $list->items;
+        if (is_object($items)) {
+            $items = (array)$items;
+        }
+
+        return count($items);
     }
 
 	/**

--- a/model/fieldtypes/SimpleListFieldDB.php
+++ b/model/fieldtypes/SimpleListFieldDB.php
@@ -43,16 +43,20 @@ class SimpleListFieldDB extends Text{
 		
 		return ( isset($list->enable) && $list->enable );
 	}
-	
-	/**
-	 * Count items
-	 */
-	public function Count(){
-		$list = $this->getList();
-		
-		return ( isset($list->items) && !empty($list->items) ) ? count($list->items) : false;
-	}
-	
+
+    /**
+     * Count items
+     */
+    public function Count(){
+        $list = $this->getList();
+
+        return (
+            isset($list->items) &&
+            !empty($list->items) &&
+            (is_array($list->items) || $list->items instanceof Countable)
+        ) ? count($list->items) : false;
+    }
+
 	/**
 	 * Get list heading
 	 */


### PR DESCRIPTION
This resolves a PHP error that was caused by an upgrade to PHP 7.3

count(): Parameter must be an array or an objet that implements Countable